### PR TITLE
Add benchmark, optimized version and safe API.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 target
 Cargo.lock
+bench/target
+bench/Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,4 @@ repository = "https://github.com/jeffcarp/luhn-rs"
 readme = "README.md"
 
 [dependencies]
-digits_iterator = "0.1"
+luhn3 = "1.0"

--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "bench"
+version = "0.1.0"
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+luhn = { path = "../" }
+
+[dev-dependencies]
+criterion = { version = "0.3", features = ["html_reports"] }
+
+[[bench]]
+name = "bench"
+harness = false

--- a/bench/benches/bench.rs
+++ b/bench/benches/bench.rs
@@ -1,0 +1,16 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+fn bench_validate(c: &mut Criterion) {
+    let isin = "4111111111111111";
+    c.bench_function("validate", |b| b.iter(|| luhn::valid(black_box(isin))));
+}
+
+fn bench_checksum(c: &mut Criterion) {
+    let s = "111111118";
+    c.bench_function("checksum", |b| {
+        b.iter(|| luhn::checksum(black_box(s.as_bytes())))
+    });
+}
+
+criterion_group!(benches, bench_validate, bench_checksum);
+criterion_main!(benches);

--- a/bench/src/lib.rs
+++ b/bench/src/lib.rs
@@ -1,0 +1,7 @@
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        assert_eq!(2 + 2, 4);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,40 +5,12 @@ card numbers, ISIN codes, etc.).  More information is available on
 [wikipedia](https://en.wikipedia.org/wiki/Luhn_algorithm).
 */
 
-use digits_iterator::DigitsExtension;
-
 /// Validates the given string using the Luhn algorithm.
 ///
 /// Typically such strings end in a check digit which is chosen in order
 /// to make the whole string validate.
 pub fn valid(pan: &str) -> bool {
-    let mut numbers = string_to_ints(pan);
-    numbers.reverse();
-    let mut is_odd: bool = true;
-    let mut odd_sum: u32 = 0;
-    let mut even_sum: u32 = 0;
-    for digit in numbers {
-        if is_odd {
-            odd_sum += digit;
-        } else {
-            even_sum += digit / 5 + (2 * digit) % 10;
-        }
-        is_odd = !is_odd
-    }
-
-    (odd_sum + even_sum) % 10 == 0
-}
-
-fn string_to_ints(string: &str) -> Vec<u32> {
-    let mut numbers = vec![];
-    for c in string.chars() {
-        let value = c.to_string().parse::<u32>();
-        match value {
-            Ok(v) => numbers.push(v),
-            Err(e) => println!("error parsing number: {:?}", e),
-        }
-    }
-    numbers
+    luhn3::valid(pan.as_bytes())
 }
 
 /// Computes the Luhn check digit for the given string.
@@ -47,57 +19,7 @@ fn string_to_ints(string: &str) -> Vec<u32> {
 /// is guaranteed to be valid.  Input must be uppercase alphanumeric
 /// ASCII; panics otherwise.
 pub fn checksum(input: &[u8]) -> u8 {
-    // This implementation is based on the description found
-    // [here](https://en.wikipedia.org/wiki/International_Securities_Identification_Number).
-
-    // Convert a char into an index into the alphabet [0-9,A-Z].
-    fn encode_char(c: u8) -> u8 {
-        match c {
-            b'0'..=b'9' => c - b'0',
-            b'A'..=b'Z' => c - b'A' + 10,
-            _ => panic!("Not alphanumeric: {}", c),
-        }
-    }
-
-    // Encode the chars in the input and concatenate them digit-wise.
-    // Eg. "3C" => [3, 1, 2]
-    // FIXME: This allocates.  Is it necessary?
-    // One char may become two digits => max length is input.len() * 2.
-    let mut ds = Vec::<u8>::with_capacity(input.len() * 2);
-    ds.extend(
-        input
-            .iter()
-            .copied()
-            .map(encode_char)
-            .flat_map(DigitsExtension::digits),
-    );
-
-    // The even-indexed digits, as numbered from the back, are added digit-wise.
-    let checksum_even = ds
-        .iter()
-        .rev()
-        .skip(1)
-        .step_by(2)
-        .copied()
-        .flat_map(DigitsExtension::digits)
-        .sum::<u8>();
-
-    // The odd-indexed digits, as numbered from the back, are doubled first.
-    let checksum_odd = ds
-        .iter()
-        .rev()
-        .step_by(2)
-        .map(|&x| x * 2)
-        .flat_map(DigitsExtension::digits)
-        .sum::<u8>();
-
-    let checksum = checksum_even + checksum_odd;
-
-    // (checksum + luhn digit) % 10 must be zero.  Working backwards:
-    let digit = (10 - (checksum % 10)) % 10;
-
-    // convert to ASCII
-    digit + 48
+    luhn3::checksum(input).expect("Input is not valid")
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,14 @@ pub fn checksum(input: &[u8]) -> u8 {
     luhn3::checksum(input).expect("Input is not valid")
 }
 
+/// Computes the Luhn check digit for the given string.
+///
+/// The string formed by appending the check digit to the original string
+/// is guaranteed to be valid.
+pub fn safe_checksum(input: &[u8]) -> Option<u8> {
+    luhn3::checksum(input)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
No rush.

   
```
    validate                time:   [24.114 ns 24.224 ns 24.352 ns]
                            change: [-93.672% -93.578% -93.502%] (p = 0.00 < 0.05)
                            Performance has improved.
    Found 11 outliers among 100 measurements (11.00%)
      1 (1.00%) low severe
      1 (1.00%) low mild
      8 (8.00%) high mild
      1 (1.00%) high severe
    
    checksum                time:   [15.117 ns 15.181 ns 15.244 ns]
                            change: [-95.164% -95.124% -95.081%] (p = 0.00 < 0.05)
                            Performance has improved.
    Found 6 outliers among 100 measurements (6.00%)
      4 (4.00%) low mild
      1 (1.00%) high mild
      1 (1.00%) high severe
```